### PR TITLE
Switch from re to 3rd-party regex module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
             'subst=subst:main',
         ],
     },
+    install_requires=["regex"]
 )
 

--- a/subst.py
+++ b/subst.py
@@ -16,7 +16,7 @@ import codecs
 import glob
 import os
 import os.path
-import re
+import regex as re
 import shutil
 import sys
 import tempfile


### PR DESCRIPTION
Switch to the more featureful, API-compatible regex module. This module
is recommended for more advanced regular expressions in Python's own
documentation: https://docs.python.org/3/library/re.html

Regex patterns can now use features such as variable-length lookarounds,
lookarounds in conditional patterns, recursive patterns, fuzzy matching,
\m and \M for the start/end of a word, and many others. See
https://pypi.org/project/regex/ for more information.